### PR TITLE
feat(load_composable_nodes): retry if no response after waiting 30 seconds when loading node

### DIFF
--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -16,6 +16,7 @@
 
 from pathlib import Path
 import threading
+import time
 
 from typing import List
 from typing import Optional
@@ -143,6 +144,9 @@ class LoadComposableNodes(Action):
 
             response_future = self.__rclpy_load_node_client.call_async(request)
             response_future.add_done_callback(unblock)
+            attempt_started = time.monotonic()
+            # maximum wait time per attempt (seconds)
+            timeout_sec = 30.0
 
             while not event.wait(1.0):
                 if context.is_shutdown:
@@ -152,6 +156,22 @@ class LoadComposableNodes(Action):
                     )
                     response_future.cancel()
                     return
+
+                # Resend if no response for 10s
+                if (time.monotonic() - attempt_started) >= timeout_sec:
+                    self.__logger.warning(
+                        "No response from '{}' for {}s; resending service call.".format(
+                            self.__rclpy_load_node_client.srv_name, timeout_sec
+                        )
+                    )
+                    response_future.cancel()
+
+                    # Reset event and unblock callback
+                    event = threading.Event()
+
+                    response_future = self.__rclpy_load_node_client.call_async(request)
+                    response_future.add_done_callback(unblock)
+                    attempt_started = time.monotonic()
 
             # Get response
             if response_future.exception() is not None:

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -157,7 +157,7 @@ class LoadComposableNodes(Action):
                     response_future.cancel()
                     return
 
-                # Resend if no response for 10s
+                # Resend if no response for timeout_sec
                 if (time.monotonic() - attempt_started) >= timeout_sec:
                     self.__logger.warning(
                         "No response from '{}' for {}s; resending service call.".format(

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -108,6 +108,49 @@ class LoadComposableNodes(Action):
 
         return cls, kwargs
 
+    def _resend_service_call_if_timeout(
+        self,
+        response_future,
+        event: threading.Event,
+        attempt_started: float,
+        timeout_sec: float,
+        request: composition_interfaces.srv.LoadNode.Request,
+        context: LaunchContext
+    ) -> tuple:
+        """
+        Resend service call if timeout occurred.
+        
+        :param response_future: current response future
+        :param event: threading event for synchronization
+        :param attempt_started: timestamp when attempt started
+        :param timeout_sec: timeout duration in seconds
+        :param request: service request to resend
+        :param context: current launch context
+        :return: tuple of (new_response_future, new_event, new_attempt_started)
+        """
+        if (time.monotonic() - attempt_started) >= timeout_sec:
+            self.__logger.warning(
+                "No response from '{}' for {}s; resending service call.".format(
+                    self.__rclpy_load_node_client.srv_name, timeout_sec
+                )
+            )
+            response_future.cancel()
+
+            # Reset event and unblock callback
+            new_event = threading.Event()
+
+            def unblock(future):
+                nonlocal new_event
+                new_event.set()
+
+            new_response_future = self.__rclpy_load_node_client.call_async(request)
+            new_response_future.add_done_callback(unblock)
+            new_attempt_started = time.monotonic()
+            
+            return new_response_future, new_event, new_attempt_started
+        
+        return response_future, event, attempt_started
+
     def _load_node(
         self,
         request: composition_interfaces.srv.LoadNode.Request,
@@ -158,20 +201,9 @@ class LoadComposableNodes(Action):
                     return
 
                 # Resend if no response for timeout_sec
-                if (time.monotonic() - attempt_started) >= timeout_sec:
-                    self.__logger.warning(
-                        "No response from '{}' for {}s; resending service call.".format(
-                            self.__rclpy_load_node_client.srv_name, timeout_sec
-                        )
-                    )
-                    response_future.cancel()
-
-                    # Reset event and unblock callback
-                    event = threading.Event()
-
-                    response_future = self.__rclpy_load_node_client.call_async(request)
-                    response_future.add_done_callback(unblock)
-                    attempt_started = time.monotonic()
+                response_future, event, attempt_started = self._resend_service_call_if_timeout(
+                    response_future, event, attempt_started, timeout_sec, request, context
+                )
 
             # Get response
             if response_future.exception() is not None:

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -115,7 +115,9 @@ class LoadComposableNodes(Action):
         attempt_started: float,
         timeout_sec: float,
         request: composition_interfaces.srv.LoadNode.Request,
-        context: LaunchContext
+        context: LaunchContext,
+        retry_count: int = 0,
+        max_retries: int = 10
     ) -> tuple:
         """
         Resend service call if timeout occurred.
@@ -126,12 +128,25 @@ class LoadComposableNodes(Action):
         :param timeout_sec: timeout duration in seconds
         :param request: service request to resend
         :param context: current launch context
-        :return: tuple of (new_response_future, new_event, new_attempt_started)
+        :param retry_count: current retry attempt count
+        :param max_retries: maximum number of retry attempts
+        :return: tuple of (new_response_future, new_event, new_attempt_started, new_retry_count)
         """
         if (time.monotonic() - attempt_started) >= timeout_sec:
+            if retry_count >= max_retries:
+                self.__logger.error(
+                    "Maximum retry attempts ({}) exceeded for '{}' service. Giving up.".format(
+                        max_retries, self.__rclpy_load_node_client.srv_name
+                    )
+                )
+                raise RuntimeError(
+                    "Failed to load node after {} retry attempts".format(max_retries)
+                )
+            
             self.__logger.warning(
-                "No response from '{}' for {}s; resending service call.".format(
-                    self.__rclpy_load_node_client.srv_name, timeout_sec
+                "No response from '{}' for {}s; resending service call (attempt {}/{}).".format(
+                    self.__rclpy_load_node_client.srv_name, timeout_sec, 
+                    retry_count + 1, max_retries
                 )
             )
             response_future.cancel()
@@ -146,10 +161,11 @@ class LoadComposableNodes(Action):
             new_response_future = self.__rclpy_load_node_client.call_async(request)
             new_response_future.add_done_callback(unblock)
             new_attempt_started = time.monotonic()
+            new_retry_count = retry_count + 1
             
-            return new_response_future, new_event, new_attempt_started
+            return new_response_future, new_event, new_attempt_started, new_retry_count
         
-        return response_future, event, attempt_started
+        return response_future, event, attempt_started, retry_count
 
     def _load_node(
         self,
@@ -190,6 +206,7 @@ class LoadComposableNodes(Action):
             attempt_started = time.monotonic()
             # maximum wait time per attempt (seconds)
             timeout_sec = 30.0
+            retry_count = 0
 
             while not event.wait(1.0):
                 if context.is_shutdown:
@@ -201,8 +218,8 @@ class LoadComposableNodes(Action):
                     return
 
                 # Resend if no response for timeout_sec
-                response_future, event, attempt_started = self._resend_service_call_if_timeout(
-                    response_future, event, attempt_started, timeout_sec, request, context
+                response_future, event, attempt_started, retry_count = self._resend_service_call_if_timeout(
+                    response_future, event, attempt_started, timeout_sec, request, context, retry_count
                 )
 
             # Get response


### PR DESCRIPTION
## Description
When launching a large number of nodes, loading nodes into a component container sometimes fails randomly.  
During this phenomenon, either the **LoadNode service request** or the **response** may be lost, causing the load to silently fail.

### Solution
This PR introduces the following changes on the client side:
- When a node load request receives no response within a certain timeout, the client will **retry sending the request**.

To prevent duplicate node loads caused by retries, the server side is updated (in the following PR) so that:
- The container will **not load a node with the same name multiple times**.

### Tests performed
No degradation in Evaluator tests.
[TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/bb0a156b-f1b7-5ce3-88b4-e01a39d43d31?project_id=prd_jt)

### Related links
Detailed investigation on this issue:
[TIER IV INTERNAL LINK](https://tier4.atlassian.net/wiki/spaces/XFST/pages/3334373620/ROS2#%E3%83%8E%E3%83%BC%E3%83%89%E3%81%8C%E8%B5%B7%E5%8B%95%E3%81%97%E3%81%AA%E3%81%84%E3%82%B1%E3%83%BC%E3%82%B91%EF%BC%9ALoadComposableNodes%E7%94%A8%E3%81%AE%E3%83%AD%E3%83%BC%E3%83%89%E3%82%B7%E3%83%BC%E3%82%B1%E3%83%B3%E3%82%B9%E3%81%8C%E3%82%B5%E3%82%A4%E3%83%AC%E3%83%B3%E3%83%88%E4%B8%AD%E6%96%AD)
[TIER IV INTERNAL JIRA](https://tier4.atlassian.net/browse/RT0-38676)

### Notes
This PR must be used together with the following PR to ensure correct behavior.
- https://github.com/tier4/rclcpp/pull/12