### PR TITLE
fix(load_composable_nodes): increase timeout for loading node

### DIFF
--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -205,7 +205,7 @@ class LoadComposableNodes(Action):
             response_future.add_done_callback(unblock)
             attempt_started = time.monotonic()
             # maximum wait time per attempt (seconds)
-            timeout_sec = 30.0
+            timeout_sec = 60.0
             retry_count = 0
 
             while not event.wait(1.0):


### PR DESCRIPTION
## Description

### Summary

This PR increases the timeout for node loading retries from 30 seconds to 60 seconds.
The reason is that some nodes may take more than 30 seconds to finish loading.

### Background

- A 30-second timeout and retry logic for node loading was introduced in the following PR.
  - https://github.com/tier4/launch_ros/pull/36
- However, some nodes can take longer than 30 seconds to load. For example, [pointcloud_map_loader](https://github.com/tier4/autoware_core/blob/c58ae3e/map/autoware_map_loader/src/pointcloud_map_loader/pointcloud_map_loader_module.cpp#L54) loads PCD files in its constructor. When the PCD file is large, the loading process takes significant time, during which the node loading process is blocked.
- In practice, when launching Autoware with an 800 MB PCD file, it took 35 seconds for pointcloud_map_loader to complete loading. Even though the node itself was actually being created, the system attempted to retry after 30 seconds.
- However, thanks to the duplicate-node check, the retry was skipped, and the system moved on to load the next node.
  - https://github.com/tier4/rclcpp/pull/12

### Motivation for Change

- It is undesirable for a timeout to occur even in a normal state (when a node is loading properly).
  - This could trigger unexpected issues and also pollute the logs
- When Autoware is launched with CARET enabled, the retry process sometimes gets triggered, causing the Autoware launch to fail.
  - This might be due to slight timing shifts caused by increased load, or because the FQN differs when CARET is enabled.

## Tests performed

- Pilot.Auto + AWSIM works as expected

## Related links

[TIER IV INTERNAL LINK](https://star4.slack.com/archives/C08V9DH68H1/p1759391779713499?thread_ts=1759127624.926879&cid=C08V9DH68H1)

## Notes for reviewers

With this change, in the rare case that a node fails to load, the startup time may increase by 30 seconds. However, since such cases are irregular, we believe this is within an acceptable range.
