### PR TITLE
cherry-pick(2759f8a): serialize composable node loading to prevent missing nodes

### DIFF
--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -58,6 +58,8 @@ from ..utilities.normalize_parameters import normalize_parameter_dict
 class LoadComposableNodes(Action):
     """Action that loads composable ROS nodes into a running container."""
 
+    lock = threading.Lock()
+
     def __init__(
         self,
         *,
@@ -119,70 +121,71 @@ class LoadComposableNodes(Action):
         :param request: service request to load a node
         :param context: current launch context
         """
-        while not self.__rclpy_load_node_client.wait_for_service(timeout_sec=1.0):
-            if context.is_shutdown:
-                self.__logger.warning(
-                    "Abandoning wait for the '{}' service, due to shutdown.".format(
-                        self.__rclpy_load_node_client.srv_name
+        with LoadComposableNodes.lock:
+            while not self.__rclpy_load_node_client.wait_for_service(timeout_sec=1.0):
+                if context.is_shutdown:
+                    self.__logger.warning(
+                        "Abandoning wait for the '{}' service, due to shutdown.".format(
+                            self.__rclpy_load_node_client.srv_name
+                        )
                     )
-                )
-                return
+                    return
 
-        # Asynchronously wait on service call so that we can periodically check for shutdown
-        event = threading.Event()
+            # Asynchronously wait on service call so that we can periodically check for shutdown
+            event = threading.Event()
 
-        def unblock(future):
-            nonlocal event
-            event.set()
+            def unblock(future):
+                nonlocal event
+                event.set()
 
-        self.__logger.debug(
-            "Calling the '{}' service with request '{}'".format(
-                self.__rclpy_load_node_client.srv_name, request
-            )
-        )
-
-        response_future = self.__rclpy_load_node_client.call_async(request)
-        response_future.add_done_callback(unblock)
-
-        while not event.wait(1.0):
-            if context.is_shutdown:
-                self.__logger.warning(
-                    "Abandoning wait for the '{}' service response, due to shutdown.".format(
-                        self.__rclpy_load_node_client.srv_name),
-                )
-                response_future.cancel()
-                return
-
-        # Get response
-        if response_future.exception() is not None:
-            raise response_future.exception()
-        response = response_future.result()
-
-        self.__logger.debug("Received response '{}'".format(response))
-
-        node_name = response.full_node_name if response.full_node_name else request.node_name
-        if response.success:
-            if node_name is not None:
-                add_node_name(context, node_name)
-                node_name_count = get_node_name_count(context, node_name)
-                if node_name_count > 1:
-                    container_logger = launch.logging.get_logger(
-                        self.__final_target_container_name
-                    )
-                    container_logger.warning(
-                        'there are now at least {} nodes with the name {} created within this '
-                        'launch context'.format(node_name_count, node_name)
-                    )
-            self.__logger.info("Loaded node '{}' in container '{}'".format(
-                response.full_node_name, self.__final_target_container_name
-            ))
-        else:
-            self.__logger.error(
-                "Failed to load node '{}' of type '{}' in container '{}': {}".format(
-                    node_name, request.plugin_name, self.__final_target_container_name,
-                    response.error_message
+            self.__logger.debug(
+                "Calling the '{}' service with request '{}'".format(
+                    self.__rclpy_load_node_client.srv_name, request
                 )
             )
+
+            response_future = self.__rclpy_load_node_client.call_async(request)
+            response_future.add_done_callback(unblock)
+
+            while not event.wait(1.0):
+                if context.is_shutdown:
+                    self.__logger.warning(
+                        "Abandoning wait for the '{}' service response, due to shutdown.".format(
+                            self.__rclpy_load_node_client.srv_name),
+                    )
+                    response_future.cancel()
+                    return
+
+            # Get response
+            if response_future.exception() is not None:
+                raise response_future.exception()
+            response = response_future.result()
+
+            self.__logger.debug("Received response '{}'".format(response))
+
+            node_name = response.full_node_name if response.full_node_name else request.node_name
+            if response.success:
+                if node_name is not None:
+                    add_node_name(context, node_name)
+                    node_name_count = get_node_name_count(context, node_name)
+                    if node_name_count > 1:
+                        container_logger = launch.logging.get_logger(
+                            self.__final_target_container_name
+                        )
+                        container_logger.warning(
+                            'there are now at least {} nodes with the name {} created within this '
+                            'launch context'.format(node_name_count, node_name)
+                        )
+                self.__logger.info("Loaded node '{}' in container '{}'".format(
+                    response.full_node_name, self.__final_target_container_name
+                ))
+            else:
+                self.__logger.error(
+                    "Failed to load node '{}' of type '{}' in container '{}': {}".format(
+                        node_name, request.plugin_name, self.__final_target_container_name,
+                        response.error_message
+                    )
+                )
 
     def _load_in_sequence(
         self,


### PR DESCRIPTION
## Background

> [!NOTE]
> ~~We will first test with upstream Jazzy. If the issue still reproduces, we will consider merging this PR together with the related fixes listed below.~~
> It reproduced.

We have observed the issue previously seen on Humble: when a large number of composable nodes are loaded during startup, a load request may occasionally fail to complete, leaving the requested node absent from its container.

The issue is rare and has only been observed when many nodes are loaded into containers concurrently.

- [TIER IV INTERNAL ticket](https://tier4.atlassian.net/browse/T4DEV-50068)
- [TIER IV INTERNAL ticket](https://tier4.atlassian.net/browse/T4DEV-53158)

## Changes

This PR serializes composable-node load operations by protecting the complete load-service transaction with a shared lock, including:

- waiting for the load service;
- sending the load request;
- waiting for the response; and
- processing the response.

This prevents multiple `LoadComposableNodes` actions from issuing concurrent load requests and reduces contention while many nodes are being loaded.

> [!WARNING]
> :warning:  Because this PR serializes composable-node load operations, **it can increase the total startup time by several seconds when loading a large number of nodes**. :warning: 


This is a cherry-pick of https://github.com/tier4/launch_ros/commit/2759f8ae5dca9d4ab517a9b5d6b5f2c66556337f.

## Related PRs

The following PRs address different failure modes involved in reliable composable-node loading:

- https://github.com/tier4/launch_ros/pull/42
  - Serializes load operations to prevent concurrent composable-node load requests.
- https://github.com/tier4/launch_ros/pull/43
  - Resends a load request if no response is received within 30 seconds.
  - Improves diagnostics for load failures.
- https://github.com/tier4/rclcpp/pull/22
  - Treats a load request as successful without loading another instance when a node with the same fully qualified name already exists.
  - Prevents duplicate node creation when a request is resent.
- https://github.com/tier4/rclcpp/pull/20
  - Retries `send_response()` when sending a service response fails.
  - Prevents the component container from terminating when the client is no longer available.

## Test plan

- [x] Launch autoware repeatedly to load a large number of composable nodes, and then check that they have all loaded.